### PR TITLE
active_translations: Activate German

### DIFF
--- a/active_translations
+++ b/active_translations
@@ -2,5 +2,6 @@
 zh_Hans,zh,简体中文,ja,
 zh_Hant,zh-Hant,繁體中文,ja,
 hu,hu,Magyar,hu,
+de,de,Deutsch,de,
 it,it,Italiano,it,
 fr,fr,Français,fr,


### PR DESCRIPTION
## Summary
- Adds `de` to `active_translations` so klipper3d.org builds the German site.
- German (`docs/locales/de/`) is complete on Weblate: 0 untranslated strings across all 57 components as of this PR.

## Test plan
- [x] `docs/locales/de/` contains all 57 `.po` files plus `Navigation.md` with all 8 TOC slots, matching the structure `build-website.sh` expects.
- [x] Verified against Weblate's live translation state (not just the GitHub mirror, which can lag).
- [x] Diff is a single line in `active_translations`, matching the format of existing entries (e.g. `hu`, `it`, `fr`).

Follows the same pattern as the prior Hungarian/Italian activation commits.